### PR TITLE
Accept function for pending property as with others

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# react-promise 
+# react-promise
 [![NPM badge](https://nodei.co/npm/react-promise.png?downloads=true&downloadRank=true&stars=true)](https://nodei.co/npm/react-promise/)
 
 a react.js component for general promise - no need for stateful component just to render a value hidden behind a promise or for a simple form.
@@ -67,7 +67,7 @@ All props are optional
 - **before** if no promise is provided, Async will invoke this inside it's render method-use for forms and such
 - **then** runs when promise is resolved. Async will run function provided in it's render passing a resolved value as first parameter.
 - **catch** runs when promise is rejected. Async will run function provided in it's render passing an error as first parameter.
-- **pending** is a React node which will be outputted from Async render method while promise is pending. If none is provided, defaults to `<div/>`
+- **pending** will run from Async render method while promise is pending.
 
 ## To use with Typescript
 

--- a/src/async.d.ts
+++ b/src/async.d.ts
@@ -5,7 +5,7 @@ export interface Props<T> {
   before?: (handlePromise: () => void) => React.ReactNode
   then?: (value: T) => React.ReactNode
   catch?: (err: any) => React.ReactNode
-  pending?: React.ReactNode
+  pending?: () => React.ReactNode
 }
 
 export interface State {

--- a/src/react-promise.js
+++ b/src/react-promise.js
@@ -58,7 +58,7 @@ class Async extends React.Component {
         break
       case statusTypes.pending:
         if (props.pending) {
-          return props.pending
+          return props.pending()
         }
         break
       case statusTypes.resolved:
@@ -81,7 +81,7 @@ Async.propTypes = {
   before: PropTypes.func, // renders it's return value before promise is handled
   then: PropTypes.func, // renders it's return value when promise is resolved
   catch: PropTypes.func, // renders it's return value when promise is rejected
-  pending: PropTypes.node, // renders it's value when promise is pending
+  pending: PropTypes.func, // renders it's value when promise is pending
   promise: PropTypes.object // promise itself
 }
 

--- a/src/react-promise.spec.js
+++ b/src/react-promise.spec.js
@@ -43,7 +43,7 @@ describe('async', function () {
 
   it('should render a supplied pending prop when promise is pending', function () {
     const wrapper = mount(
-      <Async promise={prom()} pending={<span>Loading ...</span>} />
+      <Async promise={prom()} pending={() => <span>Loading ...</span>} />
     )
     expect(wrapper.html()).toBe('<span>Loading ...</span>')
   })


### PR DESCRIPTION
Since we introduced 2.0.0/breaking changes, this is a good opportunity to unify the inputs.

Currently, the `pending` property is still an odd one out when it comes to the properties, expecting a plain `ReactNode` when all other properties take a `function`. This changes the signature to expect a function the same as the others.