### PR TITLE
Fix TypeScript typings

### DIFF
--- a/src/async.d.ts
+++ b/src/async.d.ts
@@ -5,7 +5,7 @@ export interface Props<T> {
   before?: (handlePromise: () => void) => React.ReactNode
   then?: (value: T) => React.ReactNode
   catch?: (err: any) => React.ReactNode
-  pending?: () => React.ReactNode | React.ReactNode
+  pending?: (() => React.ReactNode) | React.ReactNode
 }
 
 export interface State {
@@ -13,7 +13,7 @@ export interface State {
 }
 
 declare class Async<T> extends React.Component<Props<T>, State> {
-  defaultPending: () => React.ReactNode | React.ReactNode
+  static defaultPending: (() => React.ReactNode) | React.ReactNode
 }
 
 export default Async


### PR DESCRIPTION
Currently, pending/default pending are typed as a function that produces either a React.ReactNode or a React.ReactNode (which is obviously redundant). I'm assuming there's missing parentheses and that's not actually intended. Also defaultPending needs to be declared static.