### PR TITLE
Improve specificity of return type

### DIFF
--- a/src/usePromise.ts
+++ b/src/usePromise.ts
@@ -1,17 +1,23 @@
 import { useEffect, useState, useRef } from 'react'
 
+type PromiseState<T> = {
+  loading: true
+  error: null
+  value: undefined
+} | {
+  loading: false
+  error: null
+  value: T
+} | {
+  loading: false
+  error: Error
+  value: undefined
+};
+
 export default function usePromise<T>(
   promiseOrFn: (() => Promise<T>) | Promise<T>
-): {
-  loading: boolean
-  error: Error | null
-  value: T | undefined
-} {
-  const [state, setState] = useState<{
-    loading: boolean
-    error: Error | null
-    value: T | undefined
-  }>({
+): PromiseState<T> {
+  const [state, setState] = useState<PromiseState<T>>({
     loading: !!promiseOrFn,
     error: null,
     value: undefined
@@ -22,7 +28,7 @@ export default function usePromise<T>(
     if (!promiseOrFn) {
       setState({
         loading: false,
-        error: null,
+        error: new TypeError(`The argument passed to usePromise must be either a promise or a function, but you passed a ${typeof promiseOrFn}`),
         value: undefined
       })
     } else {


### PR DESCRIPTION
Increases the specificity of the return type. This allows consumers to make assumptions about the existence of `value` based on the value/presence of `loading` and `error`.

For example, this will produce a type error with the current version of `react-promise`, but will work as expected with these changes:

```tsx
function processMessage(input: string): string;

const messagePromise: Promise<string> = doXHRGetString();
const asyncMessage = usePromise(messagePromise);
const displayValue = asyncMessage.loading
  ? 'loading'
  : asyncMessage.error
  ? asyncMessage.error.toString()
  : processMessage(asyncMessage.value); // type error here with current version b/c `value` is type `string | undefined`
```